### PR TITLE
fix: Add missing explicit cast

### DIFF
--- a/gluon/sys/unix/gluon_unix_epoll.c
+++ b/gluon/sys/unix/gluon_unix_epoll.c
@@ -70,7 +70,7 @@ CAMLprim value gluon_unix_epoll_ctl(value v_epoll, value v_flags, value v_fd, va
     value* ocaml_value = malloc (sizeof (value*));
     *ocaml_value = Field(v_event, 0);
     caml_register_generational_global_root(ocaml_value);
-    event.data.u64 = ocaml_value;
+    event.data.u64 = (intptr_t) ocaml_value;
 
     caml_enter_blocking_section();
     int res = epoll_ctl(Int_val(v_epoll), Int_val(v_flags), Int_val(v_fd), &event);


### PR DESCRIPTION
When compiling gluon on an up-to-date Archlinux system, I run into this error.

    File "gluon/sys/unix/dune", line 11, characters 41-57:
    11 |   (names gluon_unix_io gluon_unix_kqueue gluon_unix_epoll)
                                                  ^^^^^^^^^^^^^^^^
    gluon_unix_epoll.c: In function ‘gluon_unix_epoll_ctl’:
    gluon_unix_epoll.c:73:20: error: assignment to ‘uint64_t’
      {aka ‘long unsigned int’} from ‘value *’ {aka ‘long int *’} makes
      integer from pointer without a cast [-Wint-conversion]
       73 |     event.data.u64 = ocaml_value;

This patch addresses this error by adding an explicit cast to the `intptr_t` type, as a dual for the opposite conversion in the `value` function in `epoll_event_to_record`.

```
    value epoll_event_to_record(struct epoll_event *eevent) {
      CAMLparam0();
      CAMLlocal1(event);
      event = caml_alloc_tuple(2);

  >   value *stored_value = (value *)(intptr_t)eevent->data.u64;
      Store_field(event, 0, *stored_value);
      Store_field(event, 1, Val_int(eevent->events));
      caml_remove_generational_global_root(stored_value);
      CAMLreturn(event);
    }
```