### PR TITLE
chore: Ignore _opam local switch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ _build
 *.beam
 *.trace
 test/generated/*
+_opam
 
 # nix ignores
 .direnv


### PR DESCRIPTION
It can be quite convenient to rely on a local switch when hacking a library. When doing so, Opam creates a _opam directory at the root of the repository (similarly to what Dune does with _build).

With this change, we propose to add _opam to the .gitignore file.

Obviously, feel free to discard this change if you don’t see the need for it :)