### PR TITLE
Explicitly cast ocaml_value to intptr_t

### DIFF
--- a/gluon/sys/unix/gluon_unix_epoll.c
+++ b/gluon/sys/unix/gluon_unix_epoll.c
@@ -70,7 +70,7 @@ CAMLprim value gluon_unix_epoll_ctl(value v_epoll, value v_flags, value v_fd, va
     value* ocaml_value = malloc (sizeof (value*));
     *ocaml_value = Field(v_event, 0);
     caml_register_generational_global_root(ocaml_value);
-    event.data.u64 = ocaml_value;
+    event.data.u64 = (intptr_t)ocaml_value;
 
     caml_enter_blocking_section();
     int res = epoll_ctl(Int_val(v_epoll), Int_val(v_flags), Int_val(v_fd), &event);


### PR DESCRIPTION
Closes https://github.com/riot-ml/gluon/issues/4

`gluon` seems to fail to build on Linux systems. The issue stems from `ocaml_value` being implicitly cast from a pointer to an int, instead of explicitly.

I'm actually not sure if what I'm doing here is the intended solution, but from an earlier section in the file you seem to cast from an `intptr_t` to a `value*`, so I'm assuming the reverse must hold as well.

This gets the build to pass on my Linux machine at least (Fedora 40).